### PR TITLE
plugins/Providers/Facebook/CMakeLists.txt typo fix

### DIFF
--- a/plugins/Providers/Facebook/CMakeLists.txt
+++ b/plugins/Providers/Facebook/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 link_directories (${DEPS_LIBRARY_DIRS} ${CMAKE_CURRENT_BINARY_DIR}/../../lib)
-add_definitions (${DEPS_CFLAGS}"-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
+add_definitions (${DEPS_CFLAGS} "-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
 
 set(F_NAME facebook)
 


### PR DESCRIPTION
Add a missing whitespace.

This should fix the following error:

```
cc: error: unrecognized command line option '-pthread-DGETTEXT_PACKAGE=pantheon-online-accounts'
make[2]: *** [plugins/Providers/Facebook/CMakeFiles/facebook.dir/build.make:74: plugins/Providers/Facebook/CMakeFiles/facebook.dir/facebook.c.o] Error 1
```