### PR TITLE
Update fastmail server addresses

### DIFF
--- a/plugins/Providers/FastMail/fastmail-mail.service
+++ b/plugins/Providers/FastMail/fastmail-mail.service
@@ -10,12 +10,12 @@
   <template>
     <group name="Configuration">
       <group name="IMAP">
-        <setting name="Server">mail.messagingengine.com</setting>
+        <setting name="Server">imap.fastmail.com</setting>
         <setting name="Port" type="q">993</setting>
         <setting name="Security">SSL/TLS</setting>
       </group>
       <group name="SMTP">
-        <setting name="Server">mail.messagingengine.com</setting>
+        <setting name="Server">smtp.fastmail.com</setting>
         <setting name="Port" type="q">465</setting>
         <setting name="Security">SSL/TLS</setting>
       </group>


### PR DESCRIPTION
This fixes #34 by setting new servers addresses for Fastmail. New servers addresses from here

https://www.fastmail.com/help/technical/servernamesandports.html?u=dcb0415a