### PR TITLE
Create AddAccountView

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -10,6 +10,7 @@ src/Authentification/RequestInfo.vala
 src/Authentification/RequestQueue.vala
 src/Authentification/Server.vala
 src/Authentification/WebDialog.vala
+src/Views/AddAccountView.vala
 src/Views/AccountView.vala
 src/Views/SourceSelector.vala
 src/Widgets/ACListBox.vala

--- a/src/Views/AddAccountView.vala
+++ b/src/Views/AddAccountView.vala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013-2018 elementary, Inc. (https://elementary.io)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ * Authored by: Corentin Noël <corentin@elementary.io>
+ */
+
+public class OnlineAccounts.AddAccountView : Gtk.Grid {
+    construct {
+        var primary_label = new Gtk.Label (_("Connect Your Online Accounts"));
+        primary_label.wrap = true;
+        primary_label.max_width_chars = 60;
+        primary_label.xalign = 0;
+        primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+
+        var secondary_label = new Gtk.Label (_("Sign in to connect with apps like Mail, Contacts, and Calendar."));
+        secondary_label.wrap = true;
+        secondary_label.max_width_chars = 60;
+        secondary_label.xalign = 0;
+
+        var listbox = new Gtk.ListBox ();
+        listbox.activate_on_single_click = true;
+        listbox.vexpand = true;
+
+        var manager = new Ag.Manager ();
+        foreach (var provider in manager.list_providers ()) {
+            if (provider == null || provider.get_plugin_name () == null) {
+                continue;
+            }
+            listbox.add (new AccountRow (provider));
+        }
+
+        var scrolled_window = new Gtk.ScrolledWindow (null, null);
+        scrolled_window.hscrollbar_policy = Gtk.PolicyType.NEVER;
+        scrolled_window.add (listbox);
+
+        var frame = new Gtk.Frame (null);
+        frame.margin_top = 24;
+        frame.add (scrolled_window);
+
+        halign = Gtk.Align.CENTER;
+        margin = 12;
+        orientation = Gtk.Orientation.VERTICAL;
+        add (primary_label);
+        add (secondary_label);
+        add (frame);
+
+        listbox.row_activated.connect ((row) => {
+            var provider = ((AccountRow) row).provider;
+            var ag_account = manager.create_account (provider.get_name ());
+            var selected_account = new Account (ag_account);
+            selected_account.authenticate.begin ();
+        });
+    }
+
+    private class AccountRow : Gtk.ListBoxRow {
+        public Ag.Provider provider {get; construct; }
+
+        public AccountRow (Ag.Provider provider) {
+            Object (provider: provider);
+        }
+
+        construct {
+            var image = new Gtk.Image.from_icon_name (provider.get_icon_name (), Gtk.IconSize.DND);
+            image.pixel_size = 32;
+            image.use_fallback = true;
+
+            var title_label = new Gtk.Label (provider.get_display_name ());
+            title_label.ellipsize = Pango.EllipsizeMode.END;
+            title_label.halign = Gtk.Align.START;
+
+            var description = GLib.dgettext (provider.get_i18n_domain (), provider.get_description ());
+
+            var description_label = new Gtk.Label ("<span font_size='small'>%s</span>".printf (description));
+            description_label.ellipsize = Pango.EllipsizeMode.END;
+            description_label.halign = Gtk.Align.START;
+            description_label.use_markup = true;
+
+            var grid = new Gtk.Grid ();
+            grid.margin = 6;
+            grid.column_spacing = 6;
+            grid.attach (image, 0, 0, 1, 2);
+            grid.attach (title_label, 1, 0);
+            grid.attach (description_label, 1, 1);
+
+            add (grid);
+        }
+    }
+}

--- a/src/Views/AddAccountView.vala
+++ b/src/Views/AddAccountView.vala
@@ -21,6 +21,10 @@
 
 public class OnlineAccounts.AddAccountView : Gtk.Grid {
     construct {
+        halign = Gtk.Align.CENTER;
+        margin = 12;
+        orientation = Gtk.Orientation.VERTICAL;
+
         var primary_label = new Gtk.Label (_("Connect Your Online Accounts"));
         primary_label.wrap = true;
         primary_label.max_width_chars = 60;
@@ -37,10 +41,11 @@ public class OnlineAccounts.AddAccountView : Gtk.Grid {
         listbox.vexpand = true;
 
         var manager = new Ag.Manager ();
-        foreach (var provider in manager.list_providers ()) {
+        foreach (unowned Ag.Provider provider in manager.list_providers ()) {
             if (provider == null || provider.get_plugin_name () == null) {
                 continue;
             }
+
             listbox.add (new AccountRow (provider));
         }
 
@@ -52,9 +57,6 @@ public class OnlineAccounts.AddAccountView : Gtk.Grid {
         frame.margin_top = 24;
         frame.add (scrolled_window);
 
-        halign = Gtk.Align.CENTER;
-        margin = 12;
-        orientation = Gtk.Orientation.VERTICAL;
         add (primary_label);
         add (secondary_label);
         add (frame);
@@ -68,7 +70,7 @@ public class OnlineAccounts.AddAccountView : Gtk.Grid {
     }
 
     private class AccountRow : Gtk.ListBoxRow {
-        public Ag.Provider provider {get; construct; }
+        public Ag.Provider provider { get; construct; }
 
         public AccountRow (Ag.Provider provider) {
             Object (provider: provider);

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ plug_files = files(
     'Authentification/Server.vala',
     'Authentification/WebDialog.vala',
     'Views/AccountView.vala',
+    'Views/AddAccountView.vala',
     'Views/SourceSelector.vala',
     'Widgets/ACListBox.vala',
     'Widgets/AppRow.vala',


### PR DESCRIPTION
![screenshot from 2018-11-08 10 54 04 2x](https://user-images.githubusercontent.com/7277719/48220652-be03c700-e344-11e8-927b-9e7be04f622b.png)

This changes out the welcome view for a custom view and moves it to its own class for a couple reasons:
* I want smaller icons and to move the scrolled window to the list to make it less awkward and cramped feeling when we potentially have many more providers to choose from
* I'd like to introduce a search in a follow up branch and welcome doesn't really handle that
* In a future revision I'd like to have this in a dialog instead of in view so that we can solve some weirdness with the navigation and views sliding back and forth as well as make the empty state of the plug show to the user to use the add button in the sidebar for new accounts instead of dumping them into a different interface with no instructions after adding their first account.
* Also move the infobar below this view since that's where actions should go in a linear workflow