### PR TITLE
Rename Dialog to AbstractAuthView

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,8 +1,8 @@
 src/AccountsManager.vala
 src/Account.vala
 src/Plug.vala
+src/Authentification/AbstractAuthView.vala
 src/Authentification/DialogService.vala
-src/Authentification/Dialog.vala
 src/Authentification/Key.vala
 src/Authentification/MailDialog.vala
 src/Authentification/PasswordDialog.vala

--- a/src/Authentification/AbstractAuthView.vala
+++ b/src/Authentification/AbstractAuthView.vala
@@ -35,7 +35,7 @@ public enum OnlineAccounts.SignonUIError {
     FORGOT_PASSWORD
 }
 
-public abstract class OnlineAccounts.Dialog : Gtk.Grid {
+public abstract class OnlineAccounts.AbstractAuthView : Gtk.Grid {
     public signal void finished ();
 
 
@@ -43,7 +43,7 @@ public abstract class OnlineAccounts.Dialog : Gtk.Grid {
     public string request_id;
     public OnlineAccounts.SignonUIError error_code;
 
-    protected Dialog (HashTable<string, Variant> parameter) {
+    protected AbstractAuthView (HashTable<string, Variant> parameter) {
         error_code = OnlineAccounts.SignonUIError.NONE;
         this.parameters = parameter;
         plug.hide_request.connect (() => {

--- a/src/Authentification/MailDialog.vala
+++ b/src/Authentification/MailDialog.vala
@@ -20,7 +20,7 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class OnlineAccounts.MailDialog : OnlineAccounts.Dialog {
+public class OnlineAccounts.MailDialog : OnlineAccounts.AbstractAuthView {
     Gtk.Button save_button;
 
     Gtk.Entry imap_username_entry;

--- a/src/Authentification/PasswordDialog.vala
+++ b/src/Authentification/PasswordDialog.vala
@@ -20,7 +20,7 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class OnlineAccounts.PasswordDialog : OnlineAccounts.Dialog {
+public class OnlineAccounts.PasswordDialog : OnlineAccounts.AbstractAuthView {
     public signal void refresh_captcha_needed ();
     private Gtk.Entry username_entry;
     private Gtk.Entry password_entry;

--- a/src/Authentification/RequestQueue.vala
+++ b/src/Authentification/RequestQueue.vala
@@ -29,16 +29,16 @@ public class OnlineAccounts.RequestQueue : Object {
     }
 
     Gee.LinkedList<string> widgets_to_show;
-    Gee.LinkedList<Dialog> dialogs;
+    Gee.LinkedList<AbstractAuthView> dialogs;
 
     private bool is_idle = true;
 
     private RequestQueue () {
         widgets_to_show = new Gee.LinkedList<string> ();
-        dialogs = new Gee.LinkedList<Dialog> ();
+        dialogs = new Gee.LinkedList<AbstractAuthView> ();
     }
 
-    public Dialog push_dialog (HashTable<string, Variant> parameter, GLib.MainLoop main_loop) {
+    public AbstractAuthView push_dialog (HashTable<string, Variant> parameter, GLib.MainLoop main_loop) {
         var request_info = new RequestInfo (parameter, main_loop);
         return process_next (request_info);
     }
@@ -51,8 +51,8 @@ public class OnlineAccounts.RequestQueue : Object {
         }
     }
 
-    public Dialog process_next (OnlineAccounts.RequestInfo info) {
-        Dialog dialog;
+    public AbstractAuthView process_next (OnlineAccounts.RequestInfo info) {
+        AbstractAuthView dialog;
         if (info.parameters.contains (OnlineAccounts.Key.OPEN_URL)) {
             dialog = new WebDialog (info.parameters);
             plug.add_widget_to_stack (dialog, dialog.request_id);
@@ -80,7 +80,7 @@ public class OnlineAccounts.RequestQueue : Object {
         return dialog;
     }
 
-    public Dialog? get_dialog_from_request_id (string request_id) {
+    public AbstractAuthView? get_dialog_from_request_id (string request_id) {
         foreach (var dialog in dialogs) {
             if (GLib.strcmp (dialog.request_id, request_id) == 0)
                 return dialog;

--- a/src/Authentification/WebDialog.vala
+++ b/src/Authentification/WebDialog.vala
@@ -20,7 +20,7 @@
  * Authored by: Corentin Noël <corentin@elementary.io>
  */
 
-public class OnlineAccounts.WebDialog : OnlineAccounts.Dialog {
+public class OnlineAccounts.WebDialog : OnlineAccounts.AbstractAuthView {
     private WebKit.WebView webview;
     private string oauth_open_url;
     private string oauth_final_url;

--- a/src/NewAccountDialog.vala
+++ b/src/NewAccountDialog.vala
@@ -121,7 +121,7 @@ public class OnlineAccounts.NewAccountDialog : Gtk.Dialog {
         return false;
     }
 
-    public void add_widget (OnlineAccounts.Dialog widget, string name) {
+    public void add_widget (OnlineAccounts.AbstractAuthView widget, string name) {
         stack.add_named (widget, name);
         stack.visible_child_name = name;
 

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -168,7 +168,7 @@ namespace OnlineAccounts {
             switch_to_main ();
         }
 
-        public void add_widget_to_stack (OnlineAccounts.Dialog widget, string name) {
+        public void add_widget_to_stack (OnlineAccounts.AbstractAuthView widget, string name) {
             new_account_dialog.add_widget (widget, name);
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ plug_files = files(
     'Account.vala',
     'Plug.vala',
     'Authentification/DialogService.vala',
-    'Authentification/Dialog.vala',
+    'Authentification/AbstractAuthView.vala',
     'Authentification/Key.vala',
     'Authentification/MailDialog.vala',
     'Authentification/PasswordDialog.vala',


### PR DESCRIPTION
Dialog is a bad class name and doesn't indicate what this class is actually for.

AbstractAuthView tells us that this class is:
* An Abstract class
* A view that shows authentication
* Not actually a Gtk.Dialog subclass