### PR TITLE
 build: use define_variable with pkgconfig paths

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,6 @@
 install_data(
     'com.google.code.AccountsSSO.gSingleSignOnUI.service',
-    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+    install_dir: join_paths(datadir, 'dbus-1', 'services')
 )
 
 install_data(
@@ -14,5 +14,5 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     type: 'xml',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
 )

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,11 @@ libsignon_glib = dependency('libsignon-glib')
 json_glib_dep = dependency('json-glib-1.0')
 rest_dep = dependency('rest-0.7')
 
-hicolor_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+libexecdir = join_paths(prefix, get_option('libexecdir'))
+hicolor_dir = join_paths(datadir, 'icons', 'hicolor')
 
 subdir('src')
 subdir('data')

--- a/providers/Facebook/meson.build
+++ b/providers/Facebook/meson.build
@@ -14,12 +14,12 @@ executable(
         rest_dep,
     ],
     install: true,
-    install_dir: get_option('libexecdir'),
+    install_dir: libexecdir,
 )
 
 # Install the provider
 provider_data = configuration_data()
-provider_data.set ('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+provider_data.set ('LIBEXECDIR', libexecdir)
 provider_data.set ('INTEGRATION_EXEC', provider_exe)
 configure_file(
     input: provider_name+'.provider.in',

--- a/providers/Google/meson.build
+++ b/providers/Google/meson.build
@@ -14,12 +14,12 @@ executable(
         rest_dep,
     ],
     install: true,
-    install_dir: get_option('libexecdir'),
+    install_dir: libexecdir,
 )
 
 # Install the provider
 provider_data = configuration_data()
-provider_data.set ('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+provider_data.set ('LIBEXECDIR', libexecdir)
 provider_data.set ('INTEGRATION_EXEC', provider_exe)
 configure_file(
     input: provider_name+'.provider.in',

--- a/providers/Microsoft/meson.build
+++ b/providers/Microsoft/meson.build
@@ -14,12 +14,12 @@ executable(
         rest_dep,
     ],
     install: true,
-    install_dir: get_option('libexecdir'),
+    install_dir: libexecdir,
 )
 
 # Install the provider
 provider_data = configuration_data()
-provider_data.set ('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+provider_data.set ('LIBEXECDIR', libexecdir)
 provider_data.set ('INTEGRATION_EXEC', provider_exe)
 configure_file(
     input: provider_name+'.provider.in',

--- a/providers/meson.build
+++ b/providers/meson.build
@@ -1,5 +1,5 @@
-providers_dir = libaccounts_dep.get_pkgconfig_variable('providerfilesdir')
-services_dir = libaccounts_dep.get_pkgconfig_variable('servicefilesdir')
+providers_dir = libaccounts_dep.get_pkgconfig_variable('providerfilesdir', define_variable: ['prefix', prefix])
+services_dir = libaccounts_dep.get_pkgconfig_variable('servicefilesdir', define_variable: ['prefix', prefix])
 
 subdir('Facebook')
 subdir('FastMail')

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,7 +25,7 @@ gtk_dep = dependency('gtk+-3.0')
 webkit_dep = dependency('webkit2gtk-4.0')
 
 config_data = configuration_data()
-config_data.set_quoted ('PREFIX', get_option('prefix'))
+config_data.set_quoted ('PREFIX', prefix)
 config_h = configure_file(
     output: 'config.h',
     configuration: config_data

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,8 @@ config_h = configure_file(
 config_vapi = meson.get_compiler('vala').find_library('config', dirs: meson.current_source_dir())
 config_dep = declare_dependency(dependencies: [config_vapi])
 
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
+
 shared_module(
     meson.project_name(),
     plug_files,
@@ -51,5 +53,5 @@ shared_module(
         config_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'network')
+    install_dir : join_paths(switchboard_plugsdir, 'network')
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this get_pkgconfig_variable will return a
path from within the package's prefix and we cannot write to it.
By using define_variable we can replace the respective directory
to be from the paths from meson.  This should have no affect
on elementaryOS.