### PR TITLE
Plug: Only try to destroy dialog if it's non-null

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -97,7 +97,6 @@ namespace OnlineAccounts {
                 source_selector.new_account_request.connect (() => {
                     if (new_account_dialog == null) {
                         new_account_dialog = new NewAccountDialog ();
-                        new_account_dialog.deletable = false;
                         new_account_dialog.transient_for = (Gtk.Window) main_grid.get_toplevel ();
                     }
 
@@ -125,7 +124,9 @@ namespace OnlineAccounts {
                 });
 
                 accounts_manager.account_added.connect ((account) => {
-                    new_account_dialog.destroy ();
+                    if (new_account_dialog != null) {
+                        new_account_dialog.destroy ();
+                    }
                 });
             }
 


### PR DESCRIPTION
Sometimes an account is added because of a failure to delete and not because the dialog has closed. In this case, the dialog is already null and we get an error about trying to destroy a null object

Also remove this extra `deletable`