### PR TITLE
Auto Update Account List

### DIFF
--- a/src/AccountsModel.vala
+++ b/src/AccountsModel.vala
@@ -21,6 +21,9 @@
 public class OnlineAccounts.AccountsModel : Object {
     public ListStore accounts_liststore { get; private set; }
 
+    private E.SourceRegistryWatcher collection_extension_watcher;
+    private E.SourceRegistryWatcher mail_account_extension_watcher;
+
     construct {
         accounts_liststore = new ListStore (typeof (E.Source));
 
@@ -31,7 +34,7 @@ public class OnlineAccounts.AccountsModel : Object {
         try {
             var registry = yield new E.SourceRegistry (null);
 
-            var collection_extension_watcher = new E.SourceRegistryWatcher (registry, E.SOURCE_EXTENSION_COLLECTION);
+            collection_extension_watcher = new E.SourceRegistryWatcher (registry, E.SOURCE_EXTENSION_COLLECTION);
             collection_extension_watcher.appeared.connect (add_esource);
             collection_extension_watcher.disappeared.connect (remove_esource);
             collection_extension_watcher.filter.connect ((e_source) => {
@@ -39,7 +42,7 @@ public class OnlineAccounts.AccountsModel : Object {
             });
             collection_extension_watcher.reclaim ();
 
-            var mail_account_extension_watcher = new E.SourceRegistryWatcher (registry, E.SOURCE_EXTENSION_MAIL_ACCOUNT);
+            mail_account_extension_watcher = new E.SourceRegistryWatcher (registry, E.SOURCE_EXTENSION_MAIL_ACCOUNT);
             mail_account_extension_watcher.appeared.connect (add_esource);
             mail_account_extension_watcher.disappeared.connect (remove_esource);
             mail_account_extension_watcher.filter.connect ((e_source) => {

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -19,7 +19,6 @@
 */
 
 public class OnlineAccounts.MainView : Gtk.Grid {
-
     private static AccountsModel accountsmodel;
 
     static construct {
@@ -135,7 +134,7 @@ public class OnlineAccounts.MainView : Gtk.Grid {
             var message_dialog = new Granite.MessageDialog (
                 _("Remove “%s” from this device").printf (e_source.display_name),
                 _("This account will be removed and will no longer appear in apps on this device."),
-                new ThemedIcon (icon_name),
+                new ThemedIcon.with_default_fallbacks (icon_name),
                 Gtk.ButtonsType.CANCEL
             ) {
                 badge_icon = new ThemedIcon ("edit-delete"),
@@ -146,7 +145,7 @@ public class OnlineAccounts.MainView : Gtk.Grid {
             accept_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
             if (message_dialog.run () == Gtk.ResponseType.ACCEPT) {
-                e_source.remove (null);
+                e_source.remove.begin (null);
             }
 
             message_dialog.destroy ();

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -19,9 +19,14 @@
 */
 
 public class OnlineAccounts.MainView : Gtk.Grid {
-    construct {
-        var accountsmodel = new AccountsModel ();
 
+    private static AccountsModel accountsmodel;
+
+    static construct {
+        accountsmodel = new AccountsModel ();
+    }
+
+    construct {
         var welcome = new Granite.Widgets.AlertView (
             _("Connect Your Online Accounts"),
             _("Connect online accounts by clicking the icon in the toolbar below."),


### PR DESCRIPTION
Fixes #164 by adding support for auto-updating the account list. For this to work, we need to keep the `E.SourceRegistryWatcher` instances alive. Please note: After adding a CalDAV backend, the calendar items do appear in the accounts list as well for some strange reason. Not found a solution yet for this unwanted side effect - but other than that it works quite well.