### PR TITLE
Configuring well known folder URIs

### DIFF
--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -351,11 +351,16 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
             display_name = login_page.display_name
         };
 
+        // Configuring the well known folder URI code borrows heavily from Evolution:
+        // https://gitlab.gnome.org/GNOME/evolution/-/blob/master/src/mail/e-mail-config-assistant.c#L748-761
+        var encoded_account_uid = Camel.URL.encode (account_source.uid, ":;@/");
+
         /* configure account_source */
 
         unowned var account_extension = (E.SourceMailAccount) account_source.get_extension (E.SOURCE_EXTENSION_MAIL_ACCOUNT);
         account_extension.identity_uid = identity_source.uid;
         account_extension.backend_name = "imap";
+        account_extension.archive_folder = "folder://%s/%s".printf (encoded_account_uid, Camel.URL.encode (N_("Archive"), ":;@?#"));
 
         unowned var account_security_extension = (E.SourceSecurity) account_source.get_extension (E.SOURCE_EXTENSION_SECURITY);
         account_security_extension.set_method (imap_encryption_combobox.active_id);
@@ -370,10 +375,15 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
 
         unowned var submission_extension = (E.SourceMailSubmission) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION);
         submission_extension.transport_uid = transport_source.uid;
+        submission_extension.sent_folder = "folder://%s/%s".printf (encoded_account_uid, Camel.URL.encode (N_("Sent"), ":;@?#"));
 
         unowned var identity_extension = (E.SourceMailIdentity) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_IDENTITY);
         identity_extension.address = login_page.email;
         identity_extension.name = login_page.real_name;
+
+        unowned var composition_extension = (E.SourceMailComposition) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_COMPOSITION);
+        composition_extension.drafts_folder = "folder://%s/%s".printf (encoded_account_uid, Camel.URL.encode (N_("Drafts"), ":;@?#"));
+        composition_extension.templates_folder = "folder://%s/%s".printf (encoded_account_uid, Camel.URL.encode (N_("Templates"), ":;@?#"));
 
         /* configure transport_source */
 


### PR DESCRIPTION
This PR potentially fixes https://github.com/elementary/mail/issues/620 by pre-configuring well known mail folders when a new IMAP account is added in Online Accounts:

**Before**

![Before](https://user-images.githubusercontent.com/392542/126645794-2f4143f8-1ed1-4dc7-b530-cdc8008424a0.png)

**After**

![After](https://user-images.githubusercontent.com/392542/126645813-7db26bcd-583a-4953-8c22-dea5162c5038.png)
