### PR TITLE
Auto detect auth mechanism for IMAP and SMTP

### DIFF
--- a/data/onlineaccounts.appdata.xml.in
+++ b/data/onlineaccounts.appdata.xml.in
@@ -7,6 +7,14 @@
   <icon type="stock">preferences-desktop-online-accounts</icon>
   <translation type="gettext">online-accounts-plug</translation>
   <releases>
+    <release version="6.2.0" date="2021-08-24" urgency="medium">
+      <description>
+        <ul>
+          <li>Automatically detect authentication method for IMAP</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.1.0" date="2021-07-28" urgency="medium">
       <description>
         <ul>


### PR DESCRIPTION
Fixes #203 and superseds #207.

@danrabbit thinking about this a bit more I found a more elegant solution to the problem by simply probing for LOGIN and PLAIN auth methods. This way we do not need any additional form inputs. Also I don't think most users are aware what those authentication mechanisms are anyway.