### PR TITLE
Ignore Calendar Subscriptions

### DIFF
--- a/src/Dialogs/CaldavDialog.vala
+++ b/src/Dialogs/CaldavDialog.vala
@@ -448,8 +448,20 @@ public class OnlineAccounts.CaldavDialog : Hdy.Window {
                     out calendar_user_addresses
                 );
 
+                /** Get WebDAV host: This is used to check whether we are dealing with a calendar source
+                * stored on the server itself or if its a subscription from a third party server. In case
+                * we are dealing with a calendar subscription we are going to ignore it, because we can't
+                * possibly know its credentials. So the user has to add any subscription in the corresponding
+                * app manually.
+                */
+                string? webdav_host = null;
+                if (source.has_extension (E.SOURCE_EXTENSION_WEBDAV_BACKEND)) {
+                    unowned var webdav_extension = (E.SourceWebdav) source.get_extension (E.SOURCE_EXTENSION_WEBDAV_BACKEND);
+                    webdav_host = webdav_extension.soup_uri.host;
+                }
+
                 foreach (unowned E.WebDAVDiscoveredSource? disc_source in discovered_sources) {
-                    if (disc_source == null) {
+                    if (disc_source == null || webdav_host != null && !disc_source.href.contains (webdav_host)) {
                         continue;
                     }
 


### PR DESCRIPTION
This PR fixes an synchronization error with calendar subscriptions (Screenshot from Evolution):

![Screenshot from 2021-08-30 09-36-21](https://user-images.githubusercontent.com/392542/131303648-63604b1f-d09e-4fbe-a7d5-bc6b5f3eb519.png)

The root cause here is, that we can't possibly know the credentials used to subscribe to a calendar from the 3rd party server. Therefore, if the reported WebDAV url contains another host than we are trying to connect to, we are going to ignore this calendar source and require the user to add the subscription in the corresponding app.

This fix is related to https://github.com/elementary/calendar/issues/700