### PR TITLE
Set refresh interval for IMAP

### DIFF
--- a/data/onlineaccounts.appdata.xml.in
+++ b/data/onlineaccounts.appdata.xml.in
@@ -12,6 +12,7 @@
         <ul>
           <li>Close dialogs when pressing "ESC"</li>
           <li>Make sure you can always navigate next by pressing "enter"</li>
+          <li>Make sure the refresh interval for an IMAP account is set</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -515,6 +515,10 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
         account_auth_extension.port = (uint) imap_port_spin.value;
         account_auth_extension.user = imap_username_entry.text;
 
+        unowned var refresh_extension = (E.SourceRefresh) account_source.get_extension (E.SOURCE_EXTENSION_REFRESH);
+        refresh_extension.enabled = true;
+        refresh_extension.interval_minutes = 10;
+
         /* configure identity_source */
 
         unowned var submission_extension = (E.SourceMailSubmission) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_SUBMISSION);


### PR DESCRIPTION
This PR makes sure we set the refresh interval for IMAP mail boxes. This is usefull for https://github.com/elementary/mail/pull/679 which uses this value to schedules checking for new mails per account based upon this value.