### PR TITLE
ImapDialog: Set dialog type_hint to fix parenting

### DIFF
--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -229,6 +229,7 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
         default_width = 300;
         window_position = Gtk.WindowPosition.CENTER_ON_PARENT;
         modal = true;
+        type_hint = Gdk.WindowTypeHint.DIALOG;
         add (window_handle);
 
         login_page.next_button.has_default = true;


### PR DESCRIPTION
With the latest gala changes dim parent wasn't working here. Give a dialog type hint to make sure it does