### PR TITLE
Fix use imap username for smtp

### DIFF
--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -558,7 +558,11 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
         unowned var transport_auth_extension = (E.SourceAuthentication) transport_source.get_extension (E.SOURCE_EXTENSION_AUTHENTICATION);
         transport_auth_extension.host = smtp_server_entry.text;
         transport_auth_extension.port = (uint) smtp_port_spin.value;
-        transport_auth_extension.user = smtp_username_entry.text;
+        if (use_imap_credentials.active) {
+            transport_auth_extension.user = imap_username_entry.text;
+        } else {
+            transport_auth_extension.user = smtp_username_entry.text;
+        }
 
         /* verify connection */
         unowned var session = CamelSession.get_default ();

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -288,6 +288,9 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
 
         imap_username_entry.changed.connect (() => {
             imap_username_entry.is_valid = imap_username_entry.text.length > 0;
+            if (use_imap_credentials.active) {
+                smtp_username_entry.text = imap_username_entry.text;
+            }
             set_button_sensitivity ();
         });
 


### PR DESCRIPTION
This PR fixes a bug in the flow for setting up a new IMAP account.

### Situation

The situation is as follows:

- I enter my Name, E-mail Address, Password and Display Name on the first page of the setup screen.
- The second page allows me to configure the IMAP and SMTP servers.
- I want to use the same credentials for the IMAP and SMTP server, so I leave the option 'Use IMAP Credentials' on for the SMTP section (default)
- I change my username for the IMAP server from the default value, which is my e-mail address, to the required value, which is the part before the @ symbol
- When I try to save the account settings, the SMTP section will still use  the default value for the username, the full e-mail address, instead of whatever I entered in the IMAP field.

### Solution

I added two commits to fix this. 

1. The first and primary one makes sure that we pass the IMAP username to the SMTP transport auth extension if the 'Use IMAP Credentials' option is active. This solves the original problem.
2. The second commit makes sure that as long as the Use IMAP Credentials option is active, and the user changes whatever is input into the IMAP username field, the (now hidden) SMTP username field is updated as well. When the user does decide to deactivate the Use IMAP Credentials option, the starting point is now the current IMAP username.

These fixes were tested on ElementaryOS 7 with the latest updates, and seem to work fine.
