### PR TITLE
ImapDialog: Store most initial setup keys

### DIFF
--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -843,11 +843,9 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                 break;
             case "f":
                 string folder_val = val;
-                print (folder_val + "\n");
                 if (val[0] == '/') {
                     folder_val = val.substring (1);
                 }
-                print (folder_val + "\n");
                 var full_folder_uri = "folder://%s/%s".printf (encoded_account_uri, Camel.URL.encode (val, ":;@?#"));
                 extension.set (property_name, full_folder_uri);
                 break;

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -843,8 +843,9 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                 break;
             case "f":
                 string folder_val = val;
-                if (val[0] == '/') {
-                    folder_val = val.substring (1);
+                if (folder_val[0] == '/') {
+                    int start = folder_val.index_of_nth_char (1);
+                    folder_val = folder_val.substring (start);
                 }
                 var full_folder_uri = "folder://%s/%s".printf (encoded_account_uri, Camel.URL.encode (val, ":;@?#"));
                 extension.set (property_name, full_folder_uri);

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -667,6 +667,7 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                             var save_setup_source_type = keys[0];
                             var save_setup_extension_name = keys[1];
                             var save_setup_property_name = keys[2];
+                            var type_id = keys[3];
 
                             switch (save_setup_source_type) {
                                 case "Account":
@@ -693,8 +694,33 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                                     }
                                     break;
 
+                                case "Backend":
+                                    if (!account_source.has_extension (save_setup_extension_name)) {
+                                        warning ("Backend extension '%s' not found", save_setup_extension_name);
+                                        break;
+                                    }
+
+                                    var backend_extension = account_source.get_extension (save_setup_extension_name);
+                                    switch (type_id) {
+                                        case "s":
+                                            backend_extension.set (save_setup_property_name, save_setup.get (key));
+                                            break;
+                                        case "b":
+                                            var val = bool.parse (save_setup.get (key));
+                                            backend_extension.set (save_setup_property_name, val, null);
+                                            break;
+                                        case "i":
+                                            var val = int.parse (save_setup.get (key));
+                                            backend_extension.set (save_setup_property_name, val);
+                                            break;
+                                        default: //@TODO: support type "f" (see comment above)
+                                            warning ("Unknown type identifier '%s' provided", type_id);
+                                            break;
+                                    }
+                                    break;
+
                                 default:
-                                    debug ("Initial setup key is not stored: “%s”", key);
+                                    warning ("Initial setup key is not stored: “%s”", key);
                                     break;
                             }
                         }

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -548,8 +548,6 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
         identity_extension.address = login_page.email;
         identity_extension.name = login_page.real_name;
 
-        unowned var composition_extension = (E.SourceMailComposition) identity_source.get_extension (E.SOURCE_EXTENSION_MAIL_COMPOSITION);
-
         /* configure transport_source */
 
         unowned var transport_extension = (E.SourceMailTransport) transport_source.get_extension (E.SOURCE_EXTENSION_MAIL_TRANSPORT);
@@ -693,6 +691,17 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                                     );
                                     break;
 
+                                case "Transport":
+                                    save_initial_setup_key_for_source (
+                                        transport_source,
+                                        save_setup_extension_name,
+                                        save_setup_property_name,
+                                        save_setup_property_type,
+                                        save_setup_property_value,
+                                        encoded_account_uri
+                                    );
+                                    break;
+
                                 case "Backend":
                                     save_initial_setup_key_for_source (
                                         account_source,
@@ -819,12 +828,11 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
     }
 
     private void save_initial_setup_key_for_source (E.Source source, string extension_name, string property_name, string? property_type, string val, string encoded_account_uri) {
-        if (!source.has_extension (extension_name)) {
+        unowned var extension = source.get_extension (extension_name);
+        if (extension == null) {
             warning ("Extension '%s' not found for source '%s'", extension_name, source.display_name);
             return;
         }
-
-        unowned var extension = source.get_extension (extension_name);
 
         if (property_type == null) {
             property_type = "s";

--- a/src/Dialogs/Imap/ImapDialog.vala
+++ b/src/Dialogs/Imap/ImapDialog.vala
@@ -833,14 +833,17 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
             case "s":
                 extension.set (property_name, val);
                 break;
+
             case "b":
                 var bool_val = bool.parse (val);
                 extension.set (property_name, bool_val);
                 break;
+
             case "i":
                 var int_val = int.parse (val);
                 extension.set (property_name, int_val);
                 break;
+
             case "f":
                 string folder_val = val;
                 if (folder_val[0] == '/') {
@@ -850,6 +853,7 @@ public class OnlineAccounts.ImapDialog : Hdy.Window {
                 var full_folder_uri = "folder://%s/%s".printf (encoded_account_uri, Camel.URL.encode (val, ":;@?#"));
                 extension.set (property_name, full_folder_uri);
                 break;
+
             default:
                 warning ("Unknown type identifier '%s' provided", property_type);
                 break;


### PR DESCRIPTION
The original motivation behind this was to store the `use-real-trash-path` and `real-trash-path` keys as well as the `use-real-junk-path` and `real-junk-path` keys in order to fix #232 as well as elementary/mail#749 and in preparation for elementary/mail#881

However I think it is better to not cherry pick keys to store as done previously but rather try to store all keys.
So now all keys for all source types except `Collection` (we don't use `Collection` sources) will be stored. 
Inspiration for that was how evolution does it [here](https://gitlab.gnome.org/GNOME/evolution/-/blob/master/src/libemail-engine/e-mail-store-utils.c#L406).

Partly fixes #232 
Closes elementary/mail#749