### PR TITLE
CI: unbreak fedora

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,8 @@ jobs:
       - name: Install Dependencies
         run: |
           dnf install -y git meson ninja-build vala evolution-data-server-devel glib2-devel granite-devel gtk3-devel libhandy-devel
-          git clone --depth 1 https://github.com/elementary/granite
-          dnf install -y libgee-devel
-          cd granite
-          meson build --prefix=/usr
-          ninja -C build
-          ninja -C build install
-          cd ..
-          rm -rf granite
           git clone --depth 1 --branch 6.0.2 https://github.com/elementary/switchboard
-          dnf install -y libadwaita-devel
+          dnf install -y libgee-devel
           cd switchboard
           meson build --prefix=/usr
           ninja -C build


### PR DESCRIPTION
We build granite7 because that is [not in fedora repositories](https://repology.org/project/granite/versions), but since this plug hasn't ported to gtk4 yet there should be no reason to break CI due to this (though the case here is simple as missing sassc).

With the same reason there should be no need to install libadwaita right now.

(We will have to revisit this file anyway when we port things to gtk4 I assume, since the switchboard version is hardcoded to 6.0.2)