### PR TITLE
Metainfo: Correct stock icon name

### DIFF
--- a/data/onlineaccounts.metainfo.xml.in
+++ b/data/onlineaccounts.metainfo.xml.in
@@ -6,7 +6,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
 
-  <icon type="stock">io.elementary.settings.online-accounts</icon>
+  <icon type="stock">io.elementary.settings.onlineaccounts</icon>
   <name>Online Accounts Settings</name>
   <summary>Manage online accounts and connected applications</summary>
 


### PR DESCRIPTION
The correct icon name is `gettext_name + '.svg'`, i.e. `io.elementary.settings.onlineaccounts`.

This should fix the broken icon in Feedback:

![Screenshot from 2024-09-18 21-47-28](https://github.com/user-attachments/assets/055ba4fe-ced8-42b9-92a1-931ee3c1776e)
