### PR TITLE
Add fallback icon

### DIFF
--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/elementary/settings/onlineaccounts">
+    <file alias="32x32/categories/onlineaccounts.svg" compressed="true" preprocess="xml-stripblanks">icons/32.svg</file>
+    <file alias="32x32@2/categories/onlineaccounts.svg" compressed="true" preprocess="xml-stripblanks">icons/32.svg</file>
+    <file alias="48x48/categories/onlineaccounts.svg" compressed="true" preprocess="xml-stripblanks">icons/48.svg</file>
+    <file alias="48x48@2/categories/onlineaccounts.svg" compressed="true" preprocess="xml-stripblanks">icons/48.svg</file>
+
     <file alias="32x32/categories/onlineaccounts-google.svg" compressed="true" preprocess="xml-stripblanks">icons/32/google.svg</file>
     <file alias="32x32@2/categories/onlineaccounts-google.svg" compressed="true" preprocess="xml-stripblanks">icons/32/google.svg</file>
     <file alias="48x48/categories/onlineaccounts-google.svg" compressed="true" preprocess="xml-stripblanks">icons/48/google.svg</file>


### PR DESCRIPTION
Make sure we have a fallback for if an online account type is added that we don't ship an icon for:

![Screenshot from 2025-05-02 17 23 39](https://github.com/user-attachments/assets/0b06f8ca-b19e-45d7-9f77-6f0aac419f40)
